### PR TITLE
Updated amp-fill-content to workaround IOS

### DIFF
--- a/css/amp.css
+++ b/css/amp.css
@@ -88,7 +88,8 @@ i-amp-sizer {
 
 .-amp-fill-content {
   display: block;
-  width: 100%;
+  min-width: 100%;
+  width: 1px;
   height: 100%;
   margin: auto;
 }


### PR DESCRIPTION
This commit addresses the issue described here: https://github.com/ampproject/amphtml/issues/2491
